### PR TITLE
refactor: use tailwind native aspect-ratio utility class

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@tailwindcss/aspect-ratio": "^0.4.0",
     "@types/node": "17.0.4",
     "@types/react": "17.0.38",
     "autoprefixer": "^10.4.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -45,7 +45,7 @@ function BlurImage({ image }: { image: Image }) {
 
   return (
     <a href={image.href} className="group">
-      <div className="aspect-square w-full overflow-hidden rounded-lg bg-gray-200 xl:aspect-[7/8]">
+      <div className="relative aspect-square w-full overflow-hidden rounded-lg bg-gray-200 xl:aspect-[7/8]">
         <Image
           alt=""
           src={image.imageSrc}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -45,7 +45,7 @@ function BlurImage({ image }: { image: Image }) {
 
   return (
     <a href={image.href} className="group">
-      <div className="aspect-w-1 aspect-h-1 w-full overflow-hidden rounded-lg bg-gray-200 xl:aspect-w-7 xl:aspect-h-8">
+      <div className="aspect-square w-full overflow-hidden rounded-lg bg-gray-200 xl:aspect-[7/8]">
         <Image
           alt=""
           src={image.imageSrc}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -44,8 +44,8 @@ function BlurImage({ image }: { image: Image }) {
   const [isLoading, setLoading] = useState(true)
 
   return (
-    <a href={image.href} className="group relative">
-      <div className="aspect-square w-full overflow-hidden rounded-lg bg-gray-200 xl:aspect-[7/8]">
+    <a href={image.href} className="group">
+      <div className="relative aspect-square w-full overflow-hidden rounded-lg bg-gray-200 xl:aspect-[7/8]">
         <Image
           alt=""
           src={image.imageSrc}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -44,8 +44,8 @@ function BlurImage({ image }: { image: Image }) {
   const [isLoading, setLoading] = useState(true)
 
   return (
-    <a href={image.href} className="group">
-      <div className="relative aspect-square w-full overflow-hidden rounded-lg bg-gray-200 xl:aspect-[7/8]">
+    <a href={image.href} className="group relative">
+      <div className="aspect-square w-full overflow-hidden rounded-lg bg-gray-200 xl:aspect-[7/8]">
         <Image
           alt=""
           src={image.imageSrc}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,5 +6,5 @@ module.exports = {
   theme: {
     extend: {},
   },
-  plugins: [require('@tailwindcss/aspect-ratio')],
+  plugins: [],
 }


### PR DESCRIPTION
I'm curious if there is any reason you chose to use the plugin instead of the utility class that comes with Tailwind.

Am I missing something?